### PR TITLE
Changed method signature to use interface List instead of implentation L...

### DIFF
--- a/src/main/java/com/github/jreddit/submissions/Submissions.java
+++ b/src/main/java/com/github/jreddit/submissions/Submissions.java
@@ -34,18 +34,18 @@ public class Submissions {
     }
 
     /**
-     * This function returns a linked list containing the submissions on a given
+     * This function returns a list containing the submissions on a given
      * subreddit and page. (in progress)
      *
      * @param redditName The subreddit's name
      * @param type       HOT or NEW and some others to come
      * @param frontpage       TODO this
      * @param user       The user
-     * @return The linked list containing submissions
+     * @return The list containing submissions
      * @throws IOException    If connection fails
      * @throws ParseException If JSON parsing fails
      */
-    public LinkedList<Submission> getSubmissions(String redditName,
+    public List<Submission> getSubmissions(String redditName,
                        Popularity type, Page frontpage, User user) throws IOException, ParseException {
 
         LinkedList<Submission> submissions = new LinkedList<Submission>();


### PR DESCRIPTION
Hello jRedditors! = ] Just getting started using jReddit for a project and noticed a little inconsistency in your API that I wanted to smooth out:

Changed method signature return type to use interface List instead of implementation LinkedList. Also removed JavaDoc mention of linked list to remove implementation from API documentation. This is to create a more generic API, and to be more consistent with the rest of the API that uses the interface description listed above.
