### PR TITLE
Add /by_id/ API endpoint

### DIFF
--- a/implemented_methods.md
+++ b/implemented_methods.md
@@ -252,6 +252,16 @@ SA.editUserText(comment.getFullName(),"new text");
 List<Comment> commentsFromArticle = comments.commentsFromArticle("subreddit", "articleLink", "commentId", 0, 5, 10, CommentSort.TOP);
 ```
 
+#### GET /by_id
+
+```java
+// Assuming 'subm' is a 'Submission' instance
+List<Submission> submissions = Submissions.byNames("t3_2r86db", "2r86dc");
+// Can also be called with an array
+String[] names = { "t3_2r86db", "2r86dc" };
+List<Submission> submissions2 = Submissions.byNames(names);
+```
+
 #### To be implemented:
 
 * GET /controversial

--- a/src/main/java/com/github/jreddit/retrieval/Submissions.java
+++ b/src/main/java/com/github/jreddit/retrieval/Submissions.java
@@ -353,7 +353,7 @@ public class Submissions implements ActorDriven {
      *
      * @param names             An array of fullnames (e.g. t3_15bfi0)
      */
-    protected List<Submission> byNames(String... names) {
+    public List<Submission> byNames(String... names) {
         // Don't need to specially format the parameters, as they aren't passed
         // as usual query parameters, and instead just follow the endpoint. For
         // example: reddit.com/by_id/t3_15bfi0,t3_15bfi1

--- a/src/main/java/com/github/jreddit/retrieval/Submissions.java
+++ b/src/main/java/com/github/jreddit/retrieval/Submissions.java
@@ -348,4 +348,37 @@ public class Submissions implements ActorDriven {
     	);
     }
 
+    /**
+     * Get submissions by name.
+     *
+     * @param names             An array of fullnames (e.g. t3_15bfi0)
+     */
+    protected List<Submission> byNames(String... names) {
+        // Don't need to specially format the parameters, as they aren't passed
+        // as usual query parameters, and instead just follow the endpoint. For
+        // example: reddit.com/by_id/t3_15bfi0,t3_15bfi1
+        StringBuilder paramsBuilder = new StringBuilder(normalize(names[0]));
+        for (int i=1; i<names.length; ++i) {
+            paramsBuilder.append(",");
+            paramsBuilder.append(normalize(names[i]));
+        }
+        String params = paramsBuilder.toString();
+
+        return parse(String.format(ApiEndpointUtils.SUBMISSIONS_BY_ID, params));
+    }
+
+    /**
+     * Takes a name and converts it to a submission full name
+     * (e.g. 15bfi1 -> t3_15bfi1).  If name is already a full name, it
+     * is unchanged.
+     *
+     * @param name              Submission ID (possibly without the t3_ prefix)
+     */
+    private String normalize(String name) {
+        if (name.startsWith(Kind.LINK.value())) {
+            return name;
+        }
+
+        return Kind.LINK.value() + "_" + name;
+    }
 }

--- a/src/main/java/com/github/jreddit/utils/ApiEndpointUtils.java
+++ b/src/main/java/com/github/jreddit/utils/ApiEndpointUtils.java
@@ -58,6 +58,8 @@ public class ApiEndpointUtils {
     
     public static final String SUBMISSIONS_GET = "/r/%s/%s.json?%s";
 
+    public static final String SUBMISSIONS_BY_ID = "/by_id/%s.json";
+
     /* Flair specific constants */
 
     public static final String USER_DELETE_SUBREDDIT_FLAIR = "/r/%s/api/deleteflair";

--- a/src/test/java/com/github/jreddit/retrieval/SubmissionsRetrievalTest.java
+++ b/src/test/java/com/github/jreddit/retrieval/SubmissionsRetrievalTest.java
@@ -52,6 +52,7 @@ public class SubmissionsRetrievalTest {
     private RestClient restClient;
     private User user;
     private UtilResponse normalResponse;
+    private UtilResponse singleNormalResponse;
     
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -63,6 +64,9 @@ public class SubmissionsRetrievalTest {
         restClient = mock(RestClient.class);
         subject = new Submissions(restClient, user);
         normalResponse = new UtilResponse(null, submissionListings(), 200);
+        singleNormalResponse = new UtilResponse(null,
+                                                singleSubmissionListing(),
+                                                200);
     }
     
     /**
@@ -224,6 +228,71 @@ public class SubmissionsRetrievalTest {
     	exception.expect(IllegalArgumentException.class);
         subject.search("query", QuerySyntax.LUCENE, SearchSort.NEW, TimeSpan.ALL, -1, -577, null, null, false);
     }
+
+    /**
+     * Test getting single submission by name using full names
+     */
+    @Test
+    public void testGetSingleSubmissionByFullName() {
+        // Stub REST client methods
+        String url = "/by_id/t3_redditObjName.json";
+        when(restClient.get(url, COOKIE)).thenReturn(singleNormalResponse);
+
+        // Retrieve the submissions
+        String[] names = { "t3_redditObjName" };
+        List<Submission> result = subject.byNames(names);
+        verify(restClient, times(1)).get(url, COOKIE);
+        assertEquals(1, result.size());
+        assertEquals(result.get(0).getFullName(), "t3_redditObjName");
+    }
+
+    /**
+     * Test getting multiple submissions by name using full names
+     */
+    @Test
+    public void testGetMultipleSubmissionsByFullNames() {
+        // Stub REST client methods
+        String url = "/by_id/t3_redditObjName,t3_anotherRedditObjName.json";
+        when(restClient.get(url, COOKIE)).thenReturn(normalResponse);
+
+        // Retrieve the submissions
+        String[] names = { "t3_redditObjName", "t3_anotherRedditObjName" };
+        List<Submission> result = subject.byNames(names);
+        verify(restClient, times(1)).get(url, COOKIE);
+        verifyNormalResult(result);
+    }
+    /**
+     * Test getting single submission by name using IDs
+     */
+    @Test
+    public void testGetSingleSubmissionById() {
+        // Stub REST client methods
+        String url = "/by_id/t3_redditObjName.json";
+        when(restClient.get(url, COOKIE)).thenReturn(singleNormalResponse);
+
+        // Retrieve the submissions
+        String[] names = { "redditObjName" };
+        List<Submission> result = subject.byNames(names);
+        verify(restClient, times(1)).get(url, COOKIE);
+        assertEquals(1, result.size());
+        assertEquals(result.get(0).getFullName(), "t3_redditObjName");
+    }
+
+    /**
+     * Test getting multiple submissions by name using IDs
+     */
+    @Test
+    public void testGetMultipleSubmissionsByIds() {
+        // Stub REST client methods
+        String url = "/by_id/t3_redditObjName,t3_anotherRedditObjName.json";
+        when(restClient.get(url, COOKIE)).thenReturn(normalResponse);
+
+        // Retrieve the submissions
+        String[] names = { "redditObjName", "anotherRedditObjName" };
+        List<Submission> result = subject.byNames(names);
+        verify(restClient, times(1)).get(url, COOKIE);
+        verifyNormalResult(result);
+    }
     
     /**
      * Verify that the normal result is correct.
@@ -248,4 +317,16 @@ public class SubmissionsRetrievalTest {
         return redditListing(submission1, submission2);
     }
     
+
+    /**
+     * Generate a submission listing.with only one submission
+     *
+     * @return Submission listing
+     */
+    private JSONObject singleSubmissionListing() {
+        JSONObject media = createMediaObject();
+        JSONObject mediaEmbed = createMediaEmbedObject();
+        JSONObject submission1 = createSubmission("t3_redditObjName", false, media, mediaEmbed);
+        return redditListing(submission1);
+    }
 }


### PR DESCRIPTION
I need to do some Reddit parsing, and since this library seems to support HTTPS, it seemed like the best option. However, it was missing this specific endpoint, so this pull request adds it.

I wasn't sure whether to call the method `.byNames()` or `.byIds()`. I went with the first one because it was a little easier to read. The [documentation](https://www.reddit.com/dev/api#GET_by_id_{names}) uses both names (endpoint: /by_id/, argument: names).

My code also uses spaces for indenting, since that seemed like it would match some of the other code more easily.