### PR TITLE
Fixing flaky tests in RedditScopeBuilderTest and KeyValueFormatterTest

### DIFF
--- a/src/test/java/com/github/jreddit/oauth/param/RedditScopeBuilderTest.java
+++ b/src/test/java/com/github/jreddit/oauth/param/RedditScopeBuilderTest.java
@@ -55,10 +55,11 @@ public class RedditScopeBuilderTest {
     @Test
     public void testAddMultiple() {
         builder.addScopes(RedditScope.EDIT, RedditScope.FLAIR);
+        String s = builder.build();
         assertTrue(
-                (RedditScope.EDIT.value() + RedditScope.SEPARATOR + RedditScope.FLAIR.value()).equals(builder.build()) 
+                (RedditScope.EDIT.value() + RedditScope.SEPARATOR + RedditScope.FLAIR.value()).equals(s)
                 ||
-                (RedditScope.FLAIR.value() + RedditScope.SEPARATOR + RedditScope.EDIT.value()).equals(builder.build()) 
+                (RedditScope.FLAIR.value() + RedditScope.SEPARATOR + RedditScope.EDIT.value()).equals(s)
                 );
         builder.removeScopes(RedditScope.EDIT, RedditScope.FLAIR);
     }

--- a/src/test/java/com/github/jreddit/request/util/KeyValueFormatterTest.java
+++ b/src/test/java/com/github/jreddit/request/util/KeyValueFormatterTest.java
@@ -38,10 +38,12 @@ public class KeyValueFormatterTest {
         HashMap<String, String> params = new HashMap<String, String>();
         params.put("a ", "b, ");
         params.put("c", "32626&");
+
+        String s = KeyValueFormatter.format(params, true);
         Assert.assertTrue(
-                ("a =b%2C+&c=32626%26").equals(KeyValueFormatter.format(params, true))
+                ("a =b%2C+&c=32626%26").equals(s)
                 ||
-                ("c=32626%26&a =b%2C+").equals(KeyValueFormatter.format(params, true))
+                ("c=32626%26&a =b%2C+").equals(s)
                 );
     }
     
@@ -51,11 +53,12 @@ public class KeyValueFormatterTest {
         params.put("a", "b");
         params.put("a", "b");
         params.put("b", "c");
-        
+
+        String s = KeyValueFormatter.format(params, true);
         Assert.assertTrue(
-                ("a=b&b=c").equals(KeyValueFormatter.format(params, true))
+                ("a=b&b=c").equals(s)
                 ||
-                ("b=c&a=b").equals(KeyValueFormatter.format(params, true))
+                ("b=c&a=b").equals(s)
                 );
     }
     

--- a/src/test/java/com/github/jreddit/request/util/KeyValueFormatterTest.java
+++ b/src/test/java/com/github/jreddit/request/util/KeyValueFormatterTest.java
@@ -38,7 +38,6 @@ public class KeyValueFormatterTest {
         HashMap<String, String> params = new HashMap<String, String>();
         params.put("a ", "b, ");
         params.put("c", "32626&");
-
         String s = KeyValueFormatter.format(params, true);
         Assert.assertTrue(
                 ("a =b%2C+&c=32626%26").equals(s)
@@ -53,7 +52,6 @@ public class KeyValueFormatterTest {
         params.put("a", "b");
         params.put("a", "b");
         params.put("b", "c");
-
         String s = KeyValueFormatter.format(params, true);
         Assert.assertTrue(
                 ("a=b&b=c").equals(s)


### PR DESCRIPTION
The following tests are flaky because of the underlying implementation of KeyValueFormatter.format() and builder.build() methods. Calling these methods twice can return the opposite values every time for the string values it is being compared to. Instead extracting out the method call ensures that one of the values in the assert condition will be satisfied. 

Tests:
com.github.jreddit.request.util.KeyValueFormatterTest.testFormatMultiple
com.github.jreddit.request.util.KeyValueFormatterTest.testFormatMultipleUTF8
com.github.jreddit.oauth.param.RedditScopeBuilderTest.testAddMultiple